### PR TITLE
flippingtable imports withr and paint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,8 @@ Imports:
     rlang,
     stats,
     utils
+Remotes:
+    MilesMcBain/paint
 Suggests:
     palmerpenguins,
     pillar,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Imports:
     rlang,
     stats,
     utils,
+    withr,
     paint
 Remotes:
     MilesMcBain/paint

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Imports:
     magrittr,
     rlang,
     stats,
-    utils
+    utils,
+    paint
 Remotes:
     MilesMcBain/paint
 Suggests:


### PR DESCRIPTION
@MilesMcBain, this is neat, just noticed that the package depends on `withr` and `paint` (and the remotes to `paint`).